### PR TITLE
Wait for certain period before restarting hostapd.

### DIFF
--- a/agent/gnmi/handler.go
+++ b/agent/gnmi/handler.go
@@ -18,6 +18,7 @@ package gnmi
 import (
     "errors"
     "fmt"
+    "time"
 
     "github.com/google/link022/agent/context"
     "github.com/google/link022/agent/util/ocutil"
@@ -78,6 +79,9 @@ func handleSet(op pb.UpdateResult_Operation, updatedPath *pb.Path, updatedConfig
 
     // Clean up the existing configuration.
     service.CleanupConfig(deviceConfig.ETHINTFName, changedVLANIDs)
+    
+    // Wait for link to be available again.
+    time.Sleep(5 * time.Second)
 
     // Process the incoming configuraiton.
     if err = service.ApplyConfig(officeConfig, resetIntf, deviceConfig.Hostname, deviceConfig.ETHINTFName,


### PR DESCRIPTION
Change Summary:
If start hostapd right after it stops, the WLAN link may not be ready
and causes hostapd fail to start. Thus, wait for a certain period after
hostapd stops. Eventually, we need to add a check for the status of WLAN
link before starting hostapd again.