### PR TITLE
Fix hostname to match Demo README.md

### DIFF
--- a/demo/ap_config.json
+++ b/demo/ap_config.json
@@ -2,7 +2,7 @@
   "openconfig-access-points:access-points": {
     "access-point": [
       {
-        "hostname": "raspberrypi",
+        "hostname": "link022-pi-ap",
         "system": {
           "aaa": {
             "server-groups": {


### PR DESCRIPTION
-Minor fix to ap_config.json to have it match the hostname used in the Demo.